### PR TITLE
Report add project links

### DIFF
--- a/src/js/report/report-charts.js
+++ b/src/js/report/report-charts.js
@@ -64,9 +64,9 @@ export default {
     });
 
     // Land cover chart.
-    let fields = ['lc_crop_ha', 'lc_grass_ha', 'lc_for_ha', 'lc_bar_ha', 'lc_dev_ha', 'lc_other_ha'];
-    let fieldLabels = ['Cropland', 'Grassland', 'Forest', 'Barren', 'Developed', 'Other'];
-    let categoryColors = ['#F2756C', '#40AEBB', '#FFC466', '#B6D9A3', '#FE9E68', '#C2C2C2'];
+    let fields = ['lc_crop_ha', 'lc_for_ha', 'lc_grass_ha', 'lc_dev_ha', 'lc_bar_ha', 'lc_other_ha'];
+    let fieldLabels = ['Crop', 'Forest', 'Shrub/Grassland', 'Urban', 'Bare', 'Other'];
+    let categoryColors = ['#E0A828', '#76B276', '#FFFEC1', '#FCB7CB', '#D3CE63', '#B3B3B3'];
     let dataSeries = fields.map((field, index) => {
       return { y: watershed.attributes[field], name: fieldLabels[index], color: categoryColors[index] };
     });

--- a/src/report.jade
+++ b/src/report.jade
@@ -137,6 +137,8 @@ html
               Watershed risk is defined as the change of damaging effects to watershed health and its potential to deliver critical functions in regulating water quantity and quality.
             p.
               #[span.blue We consider four watershed risks and the scores range from 1 – 5.] A high risk score indicates that the watershed health is more likely to be impacted as a result of exposure to that stressor and more urgent action is needed to mitigate the risk.
+            p.blue.
+              #[a(href='#plan-for-action') Jump] to recommendations according to watershed risk summary.
 
     hr
 
@@ -222,7 +224,8 @@ html
 
     hr
 
-    section.relative.plan 
+    section.relative.plan
+      a(id='plan-for-action')
       div.wrapper
         h2 plan for action
         h4 recommended natural infrastructure strategies

--- a/src/report.jade
+++ b/src/report.jade
@@ -42,8 +42,10 @@ html
     
     section.relative.report-header
       div.wrapper
-        div.gfw-water-logo.relative
-        div.aqueduct-logo
+        a(href='../map.html')
+          div.gfw-water-logo.relative
+        a(href='http://www.wri.org/our-work/project/aqueduct')
+          div.aqueduct-logo
         div.report-controls
           ul
             li#share-icon 


### PR DESCRIPTION
Changes for a few issues:
- blue square logo should link to map
- aqueduct logo should link to aqueduct project
- use land cover color scheme from legend in map.html
- add "Jump to recommendations" text and link
